### PR TITLE
Multiple code improvements - squid:S1118, squid:S1854, squid:CommentedOutCodeLine, squid:S1213, squid:S2184

### DIFF
--- a/xlog/src/main/java/com/sum/xlog/core/CrashHandler.java
+++ b/xlog/src/main/java/com/sum/xlog/core/CrashHandler.java
@@ -24,23 +24,24 @@ public class CrashHandler implements UncaughtExceptionHandler {
 	private static CrashHandler instance = new CrashHandler();
 	/** 当crash发生后的接口回调 **/
 	private OnCaughtCrashExceptionListener mCaughtCrashExceptionListener;
-	
-	/**
-	 * 当捕获到Crash异常后会通过该接口回调
-	 */
-	public interface OnCaughtCrashExceptionListener{
-	    void onCaughtCrashException(Thread thread, Throwable ex);
-	}
-	
-	public void setCaughtCrashExceptionListener(OnCaughtCrashExceptionListener mCaughtCrashExceptionListener)
-    {
-        this.mCaughtCrashExceptionListener = mCaughtCrashExceptionListener;
-    }
-	
+
 	/**
 	 * 保证只有一个CrashHandler实例
 	 */
 	private CrashHandler() {}
+
+	/**
+	 * 当捕获到Crash异常后会通过该接口回调
+	 */
+	public interface OnCaughtCrashExceptionListener{
+		void onCaughtCrashException(Thread thread, Throwable ex);
+
+	}
+
+	public void setCaughtCrashExceptionListener(OnCaughtCrashExceptionListener mCaughtCrashExceptionListener)
+    {
+        this.mCaughtCrashExceptionListener = mCaughtCrashExceptionListener;
+    }
 
 	/**
 	 * 获取CrashHandler实例 ,单例模式

--- a/xlog/src/main/java/com/sum/xlog/core/FileLogHelper.java
+++ b/xlog/src/main/java/com/sum/xlog/core/FileLogHelper.java
@@ -23,10 +23,17 @@ public class FileLogHelper
     private ReentrantLock mReentrantLock;
     private boolean relased = false;
     public static FileLogHelper INSTANCE = null;
-    
+
+
+    public FileLogHelper()
+    {
+        logCache = new ArrayList<String>(LOG_CACHE_POLL_SIZE);
+        mExecutorService = Executors.newSingleThreadExecutor();
+        mReentrantLock = new ReentrantLock();
+    }
 
     public static FileLogHelper getInstance(){
-        
+
         if(null == INSTANCE){
             synchronized (FileLogHelper.class){
                 if(null == INSTANCE){
@@ -35,13 +42,6 @@ public class FileLogHelper
             }
         }
         return INSTANCE;
-    }
-    
-    public FileLogHelper()
-    {
-        logCache = new ArrayList<String>(LOG_CACHE_POLL_SIZE);
-        mExecutorService = Executors.newSingleThreadExecutor();
-        mReentrantLock = new ReentrantLock();
     }
 
     public void logToFile(String log, Throwable e, String tag, int logLevel){

--- a/xlog/src/main/java/com/sum/xlog/core/LogLevel.java
+++ b/xlog/src/main/java/com/sum/xlog/core/LogLevel.java
@@ -44,4 +44,5 @@ public class LogLevel
      */
     public static byte OFF = 6;
 
+    private LogLevel() {}
 }

--- a/xlog/src/main/java/com/sum/xlog/core/XLog.java
+++ b/xlog/src/main/java/com/sum/xlog/core/XLog.java
@@ -24,7 +24,9 @@ public class XLog{
 	public static final String TAG = "XLog";
 	private static XLogConfiguration sXLogConfig;
 	private static Context sAppContext;
-	
+
+    private XLog() {}
+
 	/**
      * @Title init
      * @Description 初始化日志框架，该方法在Android application oncreate 里调用
@@ -115,13 +117,6 @@ public class XLog{
 	public static XLogConfiguration getXLogConfiguration(){
 		return sXLogConfig;
 	}
-	
-//	private static void throwExceptionIfConfigIsNull(){
-//	    
-//	    if(null == sXLogConfig){
-//	        throw new IllegalArgumentException(CONFIG_NOT_NULL);
-//	    }
-//	}
 	
 	private static boolean allowConsoleLogPrint(byte printLevel){
 	    return sXLogConfig.getConsoleLogLevel() <= printLevel && sXLogConfig.getConsoleLogLevel() != LogLevel.OFF;

--- a/xlog/src/main/java/com/sum/xlog/core/XLogConfiguration.java
+++ b/xlog/src/main/java/com/sum/xlog/core/XLogConfiguration.java
@@ -31,7 +31,7 @@ public class XLogConfiguration {
     /**
      * 默认LOG文件大小KB单位
      */
-    public static final long DEFAULT_FILE_LOG_DISK_MEMORYSIZE = 1024 * 100; //100m
+    public static final long DEFAULT_FILE_LOG_DISK_MEMORYSIZE = 1024 * 100L; //100m
     /**
      * 默认文件目录名称(获取包名目录错误的情况下使用)
      */

--- a/xlog/src/main/java/com/sum/xlog/util/DateUtil.java
+++ b/xlog/src/main/java/com/sum/xlog/util/DateUtil.java
@@ -36,6 +36,7 @@ public class DateUtil {
 	 * @brief 格式: EEE, dd-MMM-yyyy HH:mm:ss z
 	 */
 	public static final int GMT_ENGLISH_PATTERN_FLAG = 0;
+
 	/**
 	 * @brief 格式: yyyy-MM-dd HH:mm:ss
 	 */
@@ -49,7 +50,7 @@ public class DateUtil {
 	 */
 	public static final int MINUTE_PATTERN_FLAG = 3;
 	/**
-	 * @brief 格式：HH:mm:ss SSS 
+	 * @brief 格式：HH:mm:ss SSS
 	 *  - 用于记录日志打印时间
 	 */
 	public static final int TIME_PATTERN_FLAG = 4;
@@ -61,7 +62,9 @@ public class DateUtil {
 	/**
 	 * 一天时间毫秒
 	 */
-	public static final long ONE_DAY_TIME = 1000  * 60 * 60 * 24 ;
+	public static final long ONE_DAY_TIME = 1000  * 60 * 60 * 24L ;
+
+	private DateUtil() {}
 
 	/**
 	 * @brief 将日期对象格式化成指定格式的字符串
@@ -72,7 +75,7 @@ public class DateUtil {
 	 * @return String 字符串格式的日期
 	 */
 	public static String formatDate(Date date, int patternFlag) {
-		SimpleDateFormat dateFormat = null;
+		SimpleDateFormat dateFormat;
 		String dateString = "";
 		if (date == null) {
 			return dateString;
@@ -119,7 +122,7 @@ public class DateUtil {
 	 * @return Date 解析出来的日期对象，如果解析失败，则返回null
 	 */
 	public static Date parseDate(String dateString, int patternFlag) {
-		SimpleDateFormat dateFormat = null;
+		SimpleDateFormat dateFormat;
 		Date date = null;
 		if (dateString == null || "".equals(dateString.trim())) {
 			return date;
@@ -152,7 +155,7 @@ public class DateUtil {
 			case MONTH_DATE_TIME_PATTERN_FLAG:
 				dateFormat = new SimpleDateFormat(MONTH_DATE_TIME_PATTERN);
 				date = dateFormat.parse(dateString);
-				break;	
+				break;
 			default:
 				Log.w(TAG, "Unknown patternFlag:" + patternFlag);
 			}
@@ -280,7 +283,7 @@ public class DateUtil {
 	 */
 	public static String pareConferenceTime2String(String timeFormate,
 			long timemillis) {
-		String result = null;
+		String result;
 		// 输出格式转换对象
 		SimpleDateFormat outputFormat = new SimpleDateFormat(timeFormate);
 		Date date = new Date(timemillis);
@@ -331,7 +334,7 @@ public class DateUtil {
 	 * @return String 转换后的时间
 	 */
 	public static String parseLongTimeToString(Context context, long longTime) {
-		String result = null;
+		String result;
 		// 将传入的long类型时间转成Calendar对象
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTimeInMillis(longTime);
@@ -355,13 +358,7 @@ public class DateUtil {
 			result = ((hour > 9) ? hour : "0" + hour) + ":"
 					+ (minute > 9 ? minute : "0" + minute);
 			// 如果day+1==todayDay，则表示昨天，显示为昨天
-		}
-		/*
-		 * else if(year == todayYear && month == todayMonth && day+1 ==
-		 * todayDay){
-		 * result=context.getResources().getString(R.string.yestoday); }
-		 */
-		else {
+		} else {
 			result = (month + 1) + "-" + day;
 		}
 		// 返回转换后的形式

--- a/xlog/src/main/java/com/sum/xlog/util/FileUtil.java
+++ b/xlog/src/main/java/com/sum/xlog/util/FileUtil.java
@@ -27,7 +27,9 @@ import java.util.Date;
 public class FileUtil {
     private static final String TAG = "FileUtil";
     private static final String DATE_PATTERN = "yyyy-MM-dd";
-    
+
+    private FileUtil() {}
+
     public static String getSdcardPath(){
         return Environment.getExternalStorageDirectory().getAbsolutePath();
     }
@@ -48,7 +50,7 @@ public class FileUtil {
     }
     
     public static String getXLogPath(){
-    	String path = null;
+    	String path;
     	
     	XLogConfiguration xLogConfiguration = XLog.getXLogConfiguration();
     	

--- a/xlog/src/main/java/com/sum/xlog/util/OtherUtil.java
+++ b/xlog/src/main/java/com/sum/xlog/util/OtherUtil.java
@@ -18,7 +18,9 @@ public class OtherUtil {
 	public static final int SPACE_IS_NOT_ENOUGH = -1;
 
     public static String RUN_PACKAGE_NAME = "";
-	
+
+    private OtherUtil() {}
+
     /**
      * 
      * @Title getAvailableSpace


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
George Kankava
