### PR TITLE
Multiple code improvements - squid:S1444, squid:ClassVariableVisibilityCheck, squid:S1148, squid:S3008, squid:S106, squid:UselessImportCheck, squid:S1186, squid:S1488, squid:S1135

### DIFF
--- a/xlog/src/main/java/com/sum/xlog/core/CrashExceptionLogger.java
+++ b/xlog/src/main/java/com/sum/xlog/core/CrashExceptionLogger.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public class CrashExceptionLoger implements CrashHandler.OnCaughtCrashExceptionListener
+public class CrashExceptionLogger implements CrashHandler.OnCaughtCrashExceptionListener
 {
     
     public static final String TAG = "CrashExceptionProcess";
@@ -27,7 +27,7 @@ public class CrashExceptionLoger implements CrashHandler.OnCaughtCrashExceptionL
     /** 用来存储设备信息和异常信息 */
     private Map<String, String> infos = new HashMap<String, String>();
     
-    public CrashExceptionLoger(Context context)
+    public CrashExceptionLogger(Context context)
     {
         mAppContext = context;
     }

--- a/xlog/src/main/java/com/sum/xlog/core/LogLevel.java
+++ b/xlog/src/main/java/com/sum/xlog/core/LogLevel.java
@@ -18,31 +18,31 @@ public class LogLevel
     /**
      * 输出颜色为黑色的，输出大于或等于VERBOSE日志级别的信息
      **/
-    public static byte V = 0;
+    public static final byte V = 0;
     /**
      * 输出颜色是蓝色的，输出大于或等于DEBUG日志级别的信息
      **/
-    public static byte D = 1;
+    public static final byte D = 1;
     /**
      * 输出为绿色，输出大于或等于INFO日志级别的信息
      **/
-    public static byte I = 2;
+    public static final byte I = 2;
     /****
      * 输出为橙色, 输出大于或等于WARN日志级别的信息
      **/
-    public static byte W = 3;
+    public static final byte W = 3;
     /****
      * 输出为红色，仅输出ERROR日志级别的信息.
      */
-    public static byte E = 4;
+    public static final byte E = 4;
     /***
      * 只输出ASSERT级别的信息
      */
-    public static byte WTF = 5;
+    public static final byte WTF = 5;
     /**
      * 什么都不输出
      */
-    public static byte OFF = 6;
+    public static final byte OFF = 6;
 
     private LogLevel() {}
 }

--- a/xlog/src/main/java/com/sum/xlog/core/LogService.java
+++ b/xlog/src/main/java/com/sum/xlog/core/LogService.java
@@ -27,6 +27,7 @@ public class LogService extends Service{
 	}
 	
 	public LogService() {
+		// Empty default constructor
 	}
 	
 	@Override

--- a/xlog/src/main/java/com/sum/xlog/core/XLog.java
+++ b/xlog/src/main/java/com/sum/xlog/core/XLog.java
@@ -55,7 +55,7 @@ public class XLog{
 			sXLogConfig.getContext().startService(intent);
 			if(sXLogConfig.isCrashHandlerOpen()){
 			    CrashHandler.getInstance().init(sXLogConfig.getOriginalHandler());
-			    CrashHandler.getInstance().setCaughtCrashExceptionListener(new CrashExceptionLoger(sAppContext));
+			    CrashHandler.getInstance().setCaughtCrashExceptionListener(new CrashExceptionLogger(sAppContext));
 			}
 
             OtherUtil.RUN_PACKAGE_NAME = configuration.getContext().getPackageName();

--- a/xlog/src/main/java/com/sum/xlog/util/DateUtil.java
+++ b/xlog/src/main/java/com/sum/xlog/util/DateUtil.java
@@ -1,6 +1,5 @@
 package com.sum.xlog.util;
 
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -8,12 +7,10 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import android.content.ContentResolver;
 import android.content.Context;
-import android.text.TextUtils;
 import android.util.Log;
+
+import com.sum.xlog.core.XLog;
 
 /**
  * @class DateUtil
@@ -108,7 +105,7 @@ public class DateUtil {
 			dateString = dateFormat.format(date);
 			break;
 		default:
-			System.out.println("Unknown patternFlag:" + patternFlag);
+			XLog.i("Unknown patternFlag:" + patternFlag);
 		}
 		return dateString;
 	}
@@ -257,8 +254,7 @@ public class DateUtil {
 			// 将字符串格式转化成Date类型
 			date = inputFormat.parse(time);
 		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			XLog.e("Exception while parsing string date", e);
 		}
 
 		// 输出格式转换对象
@@ -266,9 +262,7 @@ public class DateUtil {
 		// 设置时区
 		outputFormat.setTimeZone(tozone);
 		// 获取转换后的值
-		String result = outputFormat.format(date);
-
-		return result;
+		return outputFormat.format(date);
 	}
 
 
@@ -304,7 +298,7 @@ public class DateUtil {
 		try {
 			date = new SimpleDateFormat(formateType).parse(str);
 		} catch (ParseException e) {
-			e.printStackTrace();
+			XLog.e("Exception while parsing string date", e);
 		}
 		return date;
 	}
@@ -320,7 +314,7 @@ public class DateUtil {
 		try {
 			date = new SimpleDateFormat("yy-MM-dd HH:mm").parse(str);
 		} catch (ParseException e) {
-			e.printStackTrace();
+			XLog.e("Exception while parsing string date", e);
 		}
 		return date;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1444 - "public static" fields should be constant.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S3008 - Static non-final field names should comply with a naming convention.
squid:S106 - Standard outputs should not be used directly to log anything.
squid:S1186 - Methods should not be empty.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1135 - "TODO" tags should be handled.
squid:UselessImportCheck - Useless imports should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S106
https://dev.eclipse.org/sonar/rules/show/squid:S1186
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1135
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
Please let me know if you have any questions.
George Kankava
